### PR TITLE
Add "Dismiss this message" feature in popup

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -41,11 +41,29 @@
   "info": {
     "message": "Info"
   },
+  "dismissed": {
+    "message": "Dismissed"
+  },
   "correct": {
     "message": "Correct"
   },
   "undo": {
     "message": "Undo"
+  },
+  "correctable": {
+    "message": "This is correctable by Correct button above"
+  },
+  "dismissIt": {
+    "message": "Dismiss this message"
+  },
+  "dismissOnlyThis": {
+    "message": "Dismiss only this message"
+  },
+  "dismissAllSame": {
+    "message": "Dismiss all the same messages"
+  },
+  "undismissIt": {
+    "message": "Cancel dismissal of this message"
   },
   "linting": {
     "message": "Checking your text..."

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -41,11 +41,29 @@
   "info": {
     "message": "情報"
   },
+  "dismissed": {
+    "message": "非通知"
+  },
   "correct": {
     "message": "自動で修正する"
   },
   "undo": {
     "message": "修正を戻す"
+  },
+  "correctable": {
+    "message": "自動修正が可能です"
+  },
+  "dismissIt": {
+    "message": "このメッセージは通知しない"
+  },
+  "dismissOnlyThis": {
+    "message": "このメッセージのみ通知しない"
+  },
+  "dismissAllSame": {
+    "message": "同じ内容のメッセージを全て通知しない"
+  },
+  "undismissIt": {
+    "message": "このメッセージを通知するようにする"
   },
   "linting": {
     "message": "文書をチェックしています…"

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -84,6 +84,12 @@
                 <span class="stat-count" id="marks-count-info"></span>
                 <span data-i18n="info">Info</span>
               </label>
+              <label class="marks-filter-item btn btn-link btn-sm" id="marks-filter-dismissed">
+                <input type="checkbox" autocomplete="off" name="filter[]" value="dismissed">
+                <i class="icon-dismissed"></i>
+                <span class="stat-count" id="marks-count-dismissed">0</span>
+                <span data-i18n="dismissed">Dismissed</span>
+              </label>
             </div>
           </div>
           <div id="marks-correct">
@@ -97,11 +103,25 @@
             </button>
           </div>
         </div>
-        <div id="marks">
+        <div id="marks" class="filter-dismissed">
           <div class="mark-item clearfix template">
-            <div class="mark-item-text"><i class="mark-severity"></i><i class="mark-correctable fa fa-check"></i><span class="mark-message"></span></div>
-            <div class="mark-item-rule">
-              <a href="#" class="mark-rule mark-link" target="_blank"></a>
+            <div class="mark-item-text"><i class="mark-severity"></i><i class="mark-correctable fa fa-check" data-i18n-attr="title:correctable"></i><span class="mark-message"></span></div>
+            <div class="mark-item-menu">
+              <a href="#" class="mark-item-menu-item mark-rule mark-link" target="_blank">
+                <i class="fa fa-home"></i>
+              </a>
+              <div class="btn-group mark-dismiss">
+                <a href="#" class="mark-item-menu-item" data-i18n-attr="title:dismissIt" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <i class="fa fa-bell-slash"></i>
+                </a>
+                <ul class="dropdown-menu dropdown-menu-right">
+                  <li><a href="#" class="mark-dismiss-this" data-i18n="dismissOnlyThis">Dismiss only this message</a></li>
+                  <li><a href="#" class="mark-dismiss-same" data-i18n="dismissAllSame">Dismiss all the same messages</a></li>
+                </ul>
+              </div>
+              <a href="#" class="mark-item-menu-item mark-undismiss" data-i18n-attr="title:undismissIt">
+                <i class="fa fa-bell"></i>
+              </a>
             </div>
           </div>
         </div>

--- a/app/scripts/lib/app/app-message.js
+++ b/app/scripts/lib/app/app-message.js
@@ -12,6 +12,7 @@ const MESSAGES = {
   LINT_RESULT: "LintResult",
   CORRECT_RESULT: "CorrectResult",
   SHOW_MARK: "ShowMark",
+  DISMISS_MARK: "DismissMark",
   TRIGGER_CORRECT: "TriggerCorrect",
   UNDO: "Undo",
   UPDATE_OPTIONS: "UpdateOptions",

--- a/app/scripts/lib/background/messages.js
+++ b/app/scripts/lib/background/messages.js
@@ -49,6 +49,10 @@ export default {
     return messages.tabSend(tabId, messages.SHOW_MARK, { markId });
   },
 
+  dismissMark(tabId, markId, dismissType) {
+    return messages.tabSend(tabId, messages.DISMISS_MARK, { markId, dismissType });
+  },
+
   triggerCorrect(tabId) {
     return messages.tabSend(tabId, messages.TRIGGER_CORRECT);
   },

--- a/app/scripts/lib/content/dismiss-type.js
+++ b/app/scripts/lib/content/dismiss-type.js
@@ -1,0 +1,9 @@
+/* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
+ * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
+"use strict";
+
+export default {
+  ONLY_THIS: "this",
+  ALL_SAME:  "same",
+  UNDISMISS: "undismiss",
+}

--- a/app/scripts/lib/content/index.js
+++ b/app/scripts/lib/content/index.js
@@ -38,8 +38,8 @@ export default function () {
   messages.onGetStatus((msg, sender, sendResponse) => {
     const active = textareaLinter ? textareaLinter.active : false;
     const marks = textareaLinter ? textareaLinter.getCurrentLintMarks() : [];
-    const counts = { info: 0, warning: 0, error: 0 };
-    marks.forEach((mark) => { counts[mark.severity]++ });
+    const counts = { info: 0, warning: 0, error: 0, dismissed: 0 };
+    marks.forEach((mark) => { counts[mark.dismissed ? "dismissed" : mark.severity]++ });
     const undoCount = textareaLinter ? textareaLinter.getCurrentUndoCount() : 0;
     sendResponse({ active, marks, counts, undoCount });
   });
@@ -78,6 +78,11 @@ export default function () {
 
   messages.onShowMark(({markId}, sender, sendResponse) => {
     if (textareaLinter) textareaLinter.showMark(markId);
+    sendResponse();
+  });
+
+  messages.onDismissMark(({markId, dismissType}, sender, sendResponse) => {
+    if (textareaLinter) textareaLinter.dismissMark(markId, dismissType);
     sendResponse();
   });
 

--- a/app/scripts/lib/content/messages.js
+++ b/app/scripts/lib/content/messages.js
@@ -33,6 +33,10 @@ export default {
     messages.on(messages.SHOW_MARK, callback);
   },
 
+  onDismissMark(callback) {
+    messages.on(messages.DISMISS_MARK, callback);
+  },
+
   onTriggerCorrect(callback) {
     messages.on(messages.TRIGGER_CORRECT, callback);
   },

--- a/app/scripts/lib/content/textarea-marker.js
+++ b/app/scripts/lib/content/textarea-marker.js
@@ -138,9 +138,11 @@ export default class TextareaMarker {
     this.$textarea.scrollTop(Math.max(0, pos.top + bgY - centerY));
 
     // Blink the marks
-    for (let i = 0; i < 2; i++) {
-      $marks.animate({ "opacity": 0 }, 300).animate({ "opacity": 1 }, 100);
-    }
+    const blinkClass = `${this.options.classPrefix}blink`;
+    $marks.removeClass(blinkClass).addClass(blinkClass)
+      .one("webkitAnimationEnd animationend", () => {
+        $marks.removeClass(blinkClass);
+      });
   }
 
   _attachBackground() {

--- a/app/styles/common.less
+++ b/app/styles/common.less
@@ -9,6 +9,7 @@
 @icon-info-color: #C2F3F4;
 @icon-warning-color: #FFF53B;
 @icon-error-color: #F47D7C;
+@icon-dismissed-color: #EDEDED;
 @lint-passed-color: #74D94F;
 @lint-info-color: #A5E7FF;
 @lint-warning-color: #FFF571;
@@ -33,5 +34,12 @@
   &:before {
     content: @fa-var-times-circle;
     color: @icon-error-color;
+  }
+}
+.fa-icon-dismissed() {
+  .fa-icon();
+  &:before {
+    content: @fa-var-bell-slash;
+    color: @icon-dismissed-color;
   }
 }

--- a/app/styles/contentscript.less
+++ b/app/styles/contentscript.less
@@ -116,4 +116,30 @@
   &.ext-textlint-error {
     background-color: fade(darken(@lint-error-color, 10%), 60%);
   }
+  &.ext-textlint-dismissed {
+    background-color: transparent;
+    box-shadow: none;
+  }
+  &.ext-textlint-blink {
+    &.ext-textlint-info {
+      background-color: darken(@lint-info-color, 20%);
+    }
+    &.ext-textlint-warning {
+      background-color: darken(@lint-warning-color, 20%);
+    }
+    &.ext-textlint-error {
+      background-color: darken(@lint-error-color, 20%);
+    }
+    -webkit-animation: 0.2s ease-in 0s 6 alternate backwards blink;
+    animation: 0.2s ease-in 0s 6 alternate backwards blink;
+  }
+}
+
+@-webkit-keyframes blink {
+  0%   { opacity: 1; }
+  100% { opacity: 0; }
+}
+@keyframes blink {
+  0%   { opacity: 1; }
+  100% { opacity: 0; }
 }

--- a/app/styles/popup.less
+++ b/app/styles/popup.less
@@ -5,9 +5,10 @@
 .icon-info { .fa-icon-info(); }
 .icon-warning { .fa-icon-warning(); }
 .icon-error { .fa-icon-error(); }
+.icon-dismissed { .fa-icon-dismissed(); }
 
 body {
-  width: 40em;
+  width: 45em;
   min-height: 25em;
   padding: 10px 0;
   overflow-y: auto;
@@ -24,7 +25,7 @@ body {
 }
 
 .settings-area {
-  margin: 30px;
+  margin: 30px 30px 30px 40%;
 
   #presets {
     margin-left: 20px;
@@ -46,6 +47,9 @@ body {
       margin: 0 3px;
       font-weight: bold;
     }
+    span {
+      text-transform: lowercase;
+    }
 
     .btn {
       min-width: 6em;
@@ -57,6 +61,7 @@ body {
       .icon-error:before { color: darken(@icon-error-color, 20%); }
       .icon-warning:before { color: darken(@icon-warning-color, 20%); }
       .icon-info:before { color: darken(@icon-info-color, 20%); }
+      .icon-dismissed:before { color: darken(@icon-dismissed-color, 20%); }
     }
   }
 
@@ -79,6 +84,7 @@ body {
     &.filter-error .mark-item-error { display: none; }
     &.filter-warning .mark-item-warning { display: none; }
     &.filter-info .mark-item-info { display: none; }
+    &.filter-dismissed .mark-item-dismissed { display: none; }
   }
 
   #no-marks {
@@ -125,13 +131,39 @@ body {
     }
   }
 
-  .mark-item-rule {
+  .mark-item-menu {
+    display: none;
     float: right;
-    font-size: 10px;
+    font-size: 12px;
     text-align: right;
-    margin-left: 10px;
+    margin-left: 7px;
     white-space: nowrap;
-    a { color: #999999; }
+
+    a.mark-item-menu-item {
+      color: #999999;
+      margin-left: 3px;
+    }
+    a.mark-item-menu-item:hover {
+      color: white;
+      text-decoration: none;
+    }
+  }
+  &:hover {
+    .mark-item-menu {
+      display: block;
+    }
+  }
+
+  .mark-undismiss {
+    display: none;
+  }
+  &.mark-item-dismissed {
+    .mark-dismiss {
+      display: none;
+    }
+    .mark-undismiss {
+      display: inline-block;
+    }
   }
 
   &:after {


### PR DESCRIPTION
#8 を実装した。ポップアップ内からメッセージの通知を抑制できる。

抑制する単位としては以下の2種類。
- `このメッセージのみ` : `severity` + `ruleId` + `message` + `text` (lint エラーとなった単語)
- `同じメッセージ全て` : `severity` + `ruleId` + `message`

`ruleId` 丸ごとの抑制はオプションからという事で今回は見送り。

`message` が変動しまくるルールがある可能性を考慮すると、`message` に代わる何かが欲しい感あるけどどうしようもない。最悪、変動する部分を特別ルールで対応するなど個別に対処する方針で。

`text` は多少前後が編集されても変化しないはずだが、対象となるテキストをいじると変化するので抑制が解除される。これは仕様とする。

あと `message` と `text` が被った場合も誤爆してしまうが、これはどうしようもない。位置で判断するわけにもいかないし。連番である `markId` を含めるという手もあるが、連番が1つズレるだけで抑制が全て解除されるのはいかがなものか。

というわけで色々と妥協の仕様が多いが、便利なので。
