### PR TITLE
Update dependencies (including major)

### DIFF
--- a/app/scripts/lib/app/bundles.js
+++ b/app/scripts/lib/app/bundles.js
@@ -1175,7 +1175,7 @@ export default {
       {
         "name": "textlint-rule-spellcheck-tech-word",
         "key": "spellcheck-tech-word",
-        "version": "4.2.0",
+        "version": "5.0.0",
         "description": "textlint rule: spell check technical word for japanese.",
         "author": "azu",
         "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "main-bower-files": "^2.11.1",
     "mocha": "^2.4.5",
     "null-loader": "^0.1.1",
-    "phantomjs-prebuilt": "^2.1.5",
+    "phantomjs-prebuilt": "^2.1.6",
     "power-assert": "^1.3.1",
     "raw-loader": "^0.5.1",
     "react": "^0.14.7",
@@ -71,7 +71,7 @@
     "sinon": "^1.17.3",
     "sinon-chrome": "^1.1.2",
     "string-replace-loader": "^1.0.0",
-    "textlint": "^6.0.1",
+    "textlint": "^6.0.2",
     "textlint-registry": "^2.2.0",
     "textlint-rule-alex": "^1.0.1",
     "textlint-rule-common-misspellings": "^1.0.1",
@@ -89,14 +89,14 @@
     "textlint-rule-no-mix-dearu-desumasu": "^1.4.0",
     "textlint-rule-no-start-duplicated-conjunction": "^1.0.7",
     "textlint-rule-preset-jtf-style": "^2.1.2",
-    "textlint-rule-rousseau": "^1.3.2",
+    "textlint-rule-rousseau": "^1.4.1",
     "textlint-rule-sentence-length": "^1.0.4",
     "textlint-rule-sjsj": "^1.0.5",
-    "textlint-rule-spellcheck-tech-word": "^4.2.0",
+    "textlint-rule-spellcheck-tech-word": "^5.0.0",
     "textlint-rule-unexpanded-acronym": "^1.2.1",
     "through2": "^2.0.1",
     "webpack": "^1.12.14",
     "webpack-stream": "^3.1.0",
-    "yargs": "^4.3.1"
+    "yargs": "^4.3.2"
   }
 }


### PR DESCRIPTION
- textlint: 6.0.1 -> 6.0.2
- textlint-rule-rousseau: 1.3.2 -> 1.4.1
  - Fixer support
- textlint-rule-spellcheck-tech-word: 4.2.0 -> 5.0.0
  - Fixer support

Major version up, but making no breaking changes. So the extension's major version will stay the same.
