### PR TITLE
Use static vendor.js to decrease build time

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -2,6 +2,7 @@ extends: airbnb
 env:
   browser: true
   webextensions: true
+  jquery: true
 plugins:
   - react
 globals:
@@ -10,6 +11,7 @@ globals:
   DEBUG: true
   LIVERELOAD: true
   JSONEditor: true
+  _: true
 rules:
   strict: 0
   arrow-body-style: 0

--- a/app/pages/options.html
+++ b/app/pages/options.html
@@ -15,7 +15,6 @@
   </div>
 
   <script src="../scripts/vendor.js"></script>
-  <script src="../scripts/jquery.js"></script>
   <script src="../bower/bootswatch-dist/js/bootstrap.min.js"></script>
   <script src="../bower/bootstrap-switch/dist/js/bootstrap-switch.js"></script>
   <script src="../bower/selectize/dist/js/standalone/selectize.min.js"></script>

--- a/app/pages/popup.html
+++ b/app/pages/popup.html
@@ -15,7 +15,6 @@
   </div>
 
   <script src="../scripts/vendor.js"></script>
-  <script src="../scripts/jquery.js"></script>
   <script src="../bower/bootswatch-dist/js/bootstrap.min.js"></script>
   <script src="../scripts/popup.js"></script>
 </body>

--- a/app/scripts/exporter/jquery.js
+++ b/app/scripts/exporter/jquery.js
@@ -1,7 +1,0 @@
-/* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
- * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
-
-import jquery from "jquery";
-
-window.jQuery = window.$ = jquery;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -16,6 +16,8 @@ module.exports = function (config) {
       "node_modules/power-assert/build/power-assert.js",
       "node_modules/sinon/pkg/sinon.js",
       "node_modules/sinon-chrome/dist/sinon-chrome.latest.js",
+      "node_modules/jquery/dist/jquery.min.js",
+      "node_modules/lodash/lodash.min.js",
       "tmp/scripts/tests.js",
     ],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "glob": "^7.0.3",
     "gulp": "^3.9.1",
     "gulp-bump": "^2.1.0",
+    "gulp-concat": "^2.6.0",
     "gulp-eslint": "^2.0.0",
     "gulp-espower": "^1.0.2",
     "gulp-filter": "^4.0.0",
@@ -99,6 +100,7 @@
     "textlint-rule-spellcheck-tech-word": "^5.0.0",
     "textlint-rule-unexpanded-acronym": "^1.2.1",
     "through2": "^2.0.1",
+    "vinyl-named": "^1.1.0",
     "webpack": "^1.12.14",
     "webpack-stream": "^3.1.0",
     "yargs": "^4.3.2"

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -13,6 +13,7 @@ gulp.task("build", gulpSequence(
     "pages",
     "locales",
     "images",
+    "vendor",
     "bower",
     "livereload",
   ]

--- a/tasks/vendor.js
+++ b/tasks/vendor.js
@@ -1,0 +1,12 @@
+import gulp from "gulp";
+import concat from "gulp-concat";
+import args from "./lib/args";
+
+gulp.task("vendor", () => {
+  return gulp.src([
+    "node_modules/jquery/dist/jquery.min.js",
+    "node_modules/lodash/lodash.min.js",
+  ])
+  .pipe(concat("vendor.js"))
+  .pipe(gulp.dest(`dist/${args.vendor}/scripts`));
+});


### PR DESCRIPTION
This PR introduces new vendor.js and decreases build time, especially for continuous build by `gulp test --watch`.
- The new task `gulp vendor` builds vendor.js which is a concatenation of jQuery and lodash.
  vendor.js exports global jQuery (`$`) and lodash (`_`) variables.
- Remove `CommonChunkPlugin` from WebPack conf so `gulp build` does not
  produce vendor.js containing common chunks any more.
- Thanks to WebPack's `externals` config, all "import jquery/lodash" now use
  global jQuery and lodash variables exported by new vendor.js, except for node_modules
  because they use old-major-version of lodash (3.x.x) and it cannot be replaced with
  the global lodash variable (4.x.x).
