### PR TITLE
Improve toolchain settings

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,5 +3,8 @@
     "es2015",
     "stage-2",
     "react"
+  ],
+  "plugins": [
+    "transform-runtime"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
     "react"
   ],
   "plugins": [
-    "transform-runtime"
+    "transform-runtime",
+    "transform-class-properties"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,7 @@
   ],
   "plugins": [
     "transform-runtime",
-    "transform-class-properties"
+    "transform-class-properties",
+    "transform-strict-mode"
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,7 @@
-{ "presets": ["es2015", "react"] }
+{
+  "presets": [
+    "es2015",
+    "stage-2",
+    "react"
+  ]
+}

--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,8 @@
   "presets": [
     "es2015",
     "stage-2",
-    "react"
+    "react",
+    "react-optimize"
   ],
   "plugins": [
     "transform-runtime",

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,10 +18,12 @@ rules:
   no-console: 0
   no-param-reassign: 0
   func-names: 0
-  quote-props: 0
   no-else-return: 0
   react/prefer-es6-class: 0
   react/prefer-stateless-function: 0
+  quote-props:
+    - error
+    - consistent
   quotes:
     - error
     - double

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,7 @@ env:
   browser: true
   webextensions: true
   jquery: true
+parser: babel-eslint
 plugins:
   - react
   - import-order
@@ -22,7 +23,6 @@ rules:
   no-param-reassign: 0
   func-names: 0
   no-else-return: 0
-  react/prefer-es6-class: 0
   react/prefer-stateless-function: 0
   quote-props:
     - error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,10 +1,13 @@
-extends: airbnb
+extends:
+  - airbnb
+  - plugin:import-order/recommended
 env:
   browser: true
   webextensions: true
   jquery: true
 plugins:
   - react
+  - import-order
 globals:
   __ENV__: true
   __VENDOR__: true

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import "./lib/background/livereload";
 import background from "./lib/background/index";

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import content from "./lib/content/index";
 

--- a/app/scripts/lib/app/app-config.js
+++ b/app/scripts/lib/app/app-config.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 export default {
   activeIcon: {

--- a/app/scripts/lib/app/app-message.js
+++ b/app/scripts/lib/app/app-message.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 

--- a/app/scripts/lib/app/app-options.js
+++ b/app/scripts/lib/app/app-options.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import appStorage from "./app-storage";

--- a/app/scripts/lib/app/app-storage.js
+++ b/app/scripts/lib/app/app-storage.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import cutil from "../util/chrome-util";
 

--- a/app/scripts/lib/app/bundles.js
+++ b/app/scripts/lib/app/bundles.js
@@ -1,7 +1,6 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 // This is auto-generated file by `gulp bundle`
-"use strict";
 
 /* eslint-disable */
 export default {

--- a/app/scripts/lib/app/sandbox-message.js
+++ b/app/scripts/lib/app/sandbox-message.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 

--- a/app/scripts/lib/background/badge.js
+++ b/app/scripts/lib/background/badge.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import cutil from "../util/chrome-util";

--- a/app/scripts/lib/background/index.js
+++ b/app/scripts/lib/background/index.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import AppOptions from "../app/app-options";

--- a/app/scripts/lib/background/linter-status.js
+++ b/app/scripts/lib/background/linter-status.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 export default class LinterStatus {
   constructor(tabId) {

--- a/app/scripts/lib/background/linters.js
+++ b/app/scripts/lib/background/linters.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import textlintRulesets from "../textlint/textlint-rulesets";

--- a/app/scripts/lib/background/messages.js
+++ b/app/scripts/lib/background/messages.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import messages from "../app/app-message";
 

--- a/app/scripts/lib/background/sandbox-client.js
+++ b/app/scripts/lib/background/sandbox-client.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import messages from "../app/sandbox-message";
 

--- a/app/scripts/lib/content/dismiss-type.js
+++ b/app/scripts/lib/content/dismiss-type.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 export default {
   ONLY_THIS: "this",

--- a/app/scripts/lib/content/index.js
+++ b/app/scripts/lib/content/index.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import messages from "./messages";
 

--- a/app/scripts/lib/content/messages.js
+++ b/app/scripts/lib/content/messages.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import messages from "../app/app-message";
 

--- a/app/scripts/lib/content/textarea-linter.js
+++ b/app/scripts/lib/content/textarea-linter.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import $ from "jquery";

--- a/app/scripts/lib/content/textarea-marker.js
+++ b/app/scripts/lib/content/textarea-marker.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import $ from "jquery";

--- a/app/scripts/lib/options/options-controller.js
+++ b/app/scripts/lib/options/options-controller.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React from "react";

--- a/app/scripts/lib/options/rule-options-fixer.js
+++ b/app/scripts/lib/options/rule-options-fixer.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 

--- a/app/scripts/lib/options/view/about/about-page.js
+++ b/app/scripts/lib/options/view/about/about-page.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import AboutSection from "./about-section";

--- a/app/scripts/lib/options/view/about/about-page.js
+++ b/app/scripts/lib/options/view/about/about-page.js
@@ -2,20 +2,22 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import AboutSection from "./about-section";
 import AuthorSection from "./author-section";
 import LicenseSection from "./license-section";
 import BundlesSection from "./bundles-section";
 
-const AboutPage = React.createClass({
-  propTypes: {
-    bundles: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    onReady: React.PropTypes.func.isRequired,
-  },
+export default class AboutPage extends React.Component {
+  static propTypes = {
+    bundles: PropTypes.arrayOf(PropTypes.object).isRequired,
+    onReady: PropTypes.func.isRequired,
+  };
+
   componentDidMount() {
     this.props.onReady();
-  },
+  }
+
   render() {
     return (
       <div className="about-page">
@@ -25,7 +27,5 @@ const AboutPage = React.createClass({
         <BundlesSection bundles={this.props.bundles} />
       </div>
     );
-  },
-});
-
-export default AboutPage;
+  }
+}

--- a/app/scripts/lib/options/view/about/about-section.js
+++ b/app/scripts/lib/options/view/about/about-section.js
@@ -6,7 +6,7 @@ import React from "react";
 import { translate } from "../../../util/chrome-util";
 import Paragraph from "./paragraph";
 
-const AboutSection = React.createClass({
+export default class AboutSection extends React.Component {
   render() {
     return (
       <div className="about-section">
@@ -16,7 +16,5 @@ const AboutSection = React.createClass({
         <Paragraph text="aboutS1P3" />
       </div>
     );
-  },
-});
-
-export default AboutSection;
+  }
+}

--- a/app/scripts/lib/options/view/about/about-section.js
+++ b/app/scripts/lib/options/view/about/about-section.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/about/author-section.js
+++ b/app/scripts/lib/options/view/about/author-section.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/about/author-section.js
+++ b/app/scripts/lib/options/view/about/author-section.js
@@ -6,13 +6,19 @@ import React from "react";
 import { translate } from "../../../util/chrome-util";
 import Paragraph from "./paragraph";
 
-const AuthorSection = React.createClass({
+export default class AuthorSection extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleMailClick = this.handleMailClick.bind(this);
+  }
+
   handleMailClick(e) {
     e.preventDefault();
     chrome.tabs.create({ url: e.target.href }, (tab) => {
       setTimeout(() => { chrome.tabs.remove(tab.id); }, 500);
     });
-  },
+  }
+
   render() {
     return (
       <div className="author-section">
@@ -41,7 +47,5 @@ const AuthorSection = React.createClass({
         </ul>
       </div>
     );
-  },
-});
-
-export default AuthorSection;
+  }
+}

--- a/app/scripts/lib/options/view/about/bundles-section.js
+++ b/app/scripts/lib/options/view/about/bundles-section.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/about/bundles-section.js
+++ b/app/scripts/lib/options/view/about/bundles-section.js
@@ -2,20 +2,21 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 import Paragraph from "./paragraph";
 
-const BundlesSection = React.createClass({
-  propTypes: {
-    bundles: React.PropTypes.arrayOf(React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      version: React.PropTypes.string.isRequired,
-      author: React.PropTypes.string.isRequired,
-      license: React.PropTypes.string.isRequired,
-      homepage: React.PropTypes.string.isRequired,
+export default class BundlesSection extends React.Component {
+  static propTypes = {
+    bundles: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      version: PropTypes.string.isRequired,
+      author: PropTypes.string.isRequired,
+      license: PropTypes.string.isRequired,
+      homepage: PropTypes.string.isRequired,
     })).isRequired,
-  },
+  };
+
   render() {
     return (
       <div className="bundles-section">
@@ -43,7 +44,5 @@ const BundlesSection = React.createClass({
         </table>
       </div>
     );
-  },
-});
-
-export default BundlesSection;
+  }
+}

--- a/app/scripts/lib/options/view/about/license-section.js
+++ b/app/scripts/lib/options/view/about/license-section.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/about/license-section.js
+++ b/app/scripts/lib/options/view/about/license-section.js
@@ -6,7 +6,7 @@ import React from "react";
 import { translate } from "../../../util/chrome-util";
 import Paragraph from "./paragraph";
 
-const LicenseSection = React.createClass({
+export default class LicenseSection extends React.Component {
   render() {
     return (
       <div className="license-section">
@@ -14,7 +14,5 @@ const LicenseSection = React.createClass({
         <Paragraph text="aboutS3P1" />
       </div>
     );
-  },
-});
-
-export default LicenseSection;
+  }
+}

--- a/app/scripts/lib/options/view/about/paragraph.js
+++ b/app/scripts/lib/options/view/about/paragraph.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/footer/footer-panel.js
+++ b/app/scripts/lib/options/view/footer/footer-panel.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/footer/footer-panel.js
+++ b/app/scripts/lib/options/view/footer/footer-panel.js
@@ -2,22 +2,22 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const FooterLinks = [
-  { icon: "twitter", title: "@io_monad", url: "https://twitter.com/io_monad" },
-  { icon: "github", title: "@io-monad", url: "https://github.com/io-monad" },
-  { icon: "code-fork", title: "Fork me", url: "https://github.com/io-monad/textlint-chrome-extension" },
-];
+export default class FooterPanel extends React.Component {
+  static propTypes = {
+    appVersion: PropTypes.string.isRequired,
+    appStoreURL: PropTypes.string.isRequired,
+    saveEnabled: PropTypes.bool.isRequired,
+    onSaveClick: PropTypes.func.isRequired,
+  };
+  static links = [
+    { icon: "twitter", title: "@io_monad", url: "https://twitter.com/io_monad" },
+    { icon: "github", title: "@io-monad", url: "https://github.com/io-monad" },
+    { icon: "code-fork", title: "Fork me", url: "https://github.com/io-monad/textlint-chrome-extension" },
+  ];
 
-const FooterPanel = React.createClass({
-  propTypes: {
-    appVersion: React.PropTypes.string.isRequired,
-    appStoreURL: React.PropTypes.string.isRequired,
-    saveEnabled: React.PropTypes.bool.isRequired,
-    onSaveClick: React.PropTypes.func.isRequired,
-  },
   render() {
     const { appVersion, appStoreURL, saveEnabled } = this.props;
     return (
@@ -31,7 +31,7 @@ const FooterPanel = React.createClass({
               <i className="fa fa-star fa-lg"></i>
               Rate me!
             </a>
-            {FooterLinks.map(link =>
+            {FooterPanel.links.map(link =>
               <a
                 key={link.icon} href={link.url} target="_blank"
                 className="btn btn-link btn-sm icon-button"
@@ -53,7 +53,5 @@ const FooterPanel = React.createClass({
         </div>
       </div>
     );
-  },
-});
-
-export default FooterPanel;
+  }
+}

--- a/app/scripts/lib/options/view/json-editor/editor-checkboxed-editor.js
+++ b/app/scripts/lib/options/view/json-editor/editor-checkboxed-editor.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import $ from "jquery";

--- a/app/scripts/lib/options/view/json-editor/editor-enumconstant.js
+++ b/app/scripts/lib/options/view/json-editor/editor-enumconstant.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 JSONEditor.defaults.resolvers.unshift((schema) => {
   if (schema.enum && schema.enum.length === 1) {

--- a/app/scripts/lib/options/view/json-editor/editor-multiselectize.js
+++ b/app/scripts/lib/options/view/json-editor/editor-multiselectize.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import $ from "jquery";

--- a/app/scripts/lib/options/view/json-editor/fix-schema.js
+++ b/app/scripts/lib/options/view/json-editor/fix-schema.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 

--- a/app/scripts/lib/options/view/json-editor/json-editor.js
+++ b/app/scripts/lib/options/view/json-editor/json-editor.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import $ from "jquery";

--- a/app/scripts/lib/options/view/json-editor/json-editor.js
+++ b/app/scripts/lib/options/view/json-editor/json-editor.js
@@ -4,7 +4,7 @@
 
 import _ from "lodash";
 import $ from "jquery";
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 import fixSchema from "./fix-schema";
 import "./editor-multiselectize";
@@ -16,13 +16,14 @@ JSONEditor.defaults.options.theme = "bootstrap3";
 JSONEditor.defaults.options.iconlib = "fontawesome4";
 JSONEditor.plugins.selectize.enable = true;
 
-const JsonEditor = React.createClass({
-  propTypes: {
-    schema: React.PropTypes.object.isRequired,
-    defaultValue: React.PropTypes.any,
-    onReady: React.PropTypes.func,
-    onChange: React.PropTypes.func,
-  },
+export default class JsonEditor extends React.Component {
+  static propTypes = {
+    schema: PropTypes.object.isRequired,
+    defaultValue: PropTypes.any,
+    onReady: PropTypes.func,
+    onChange: PropTypes.func,
+  };
+
   componentDidMount() {
     const editor = new JSONEditor(this.refs.editor, {
       schema: fixSchema(this.props.schema),
@@ -36,10 +37,11 @@ const JsonEditor = React.createClass({
       if (this.props.onChange) this.props.onChange(editor);
     });
     this.editor = editor;
-  },
+  }
   componentWillUnmount() {
     this.editor = null;
-  },
+  }
+
   translateLabels() {
     $(this.refs.editor).find("label").contents()
       .filter(function () {
@@ -52,19 +54,18 @@ const JsonEditor = React.createClass({
           this.nodeValue = translate(key, this.nodeValue);
         }
       });
-  },
+  }
   validate() {
     return this.editor.validate();
-  },
+  }
   serialize() {
     return this.editor.getValue();
-  },
+  }
+
   render() {
     return (
       <div className="json-editor" ref="editor">
       </div>
     );
-  },
-});
-
-export default JsonEditor;
+  }
+}

--- a/app/scripts/lib/options/view/options-view.js
+++ b/app/scripts/lib/options/view/options-view.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/options/view/options-view.js
+++ b/app/scripts/lib/options/view/options-view.js
@@ -3,7 +3,7 @@
 "use strict";
 
 import _ from "lodash";
-import React from "react";
+import React, { PropTypes } from "react";
 import PageSwitch from "./pages/page-switch";
 import PagePanel from "./pages/page-panel";
 import RulesPage from "./rules/rules-page";
@@ -11,44 +11,56 @@ import VisualPage from "./visual/visual-page";
 import AboutPage from "./about/about-page";
 import FooterPanel from "./footer/footer-panel";
 
-const OptionsView = React.createClass({
-  propTypes: {
-    controller: React.PropTypes.object.isRequired,
-    bundles: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    rules: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    appOptions: React.PropTypes.object.isRequired,
-    appVersion: React.PropTypes.string.isRequired,
-    appStoreURL: React.PropTypes.string.isRequired,
-  },
-  getInitialState() {
-    return {
+export default class OptionsView extends React.Component {
+  static propTypes = {
+    controller: PropTypes.object.isRequired,
+    bundles: PropTypes.arrayOf(PropTypes.object).isRequired,
+    rules: PropTypes.arrayOf(PropTypes.object).isRequired,
+    appOptions: PropTypes.object.isRequired,
+    appVersion: PropTypes.string.isRequired,
+    appStoreURL: PropTypes.string.isRequired,
+  };
+  static pages = [
+    { name: "rules", menuTitle: "menuRules", pageTitle: "customizeRules", icon: "pencil" },
+    { name: "visual", menuTitle: "menuVisual", pageTitle: "visualEffects", icon: "eye" },
+    { name: "about", menuTitle: "menuAbout", pageTitle: "aboutExtension", icon: "info-circle" },
+  ];
+
+  constructor(props) {
+    super(props);
+    this.state = {
       saveEnabled: false,
       activePage: null,
     };
-  },
+
+    this.handlePageReady = this.handlePageReady.bind(this);
+    this.handlePageChange = this.handlePageChange.bind(this);
+    this.handleSaveClick = this.handleSaveClick.bind(this);
+  }
+
   componentWillMount() {
     this.readyPageCount = 0;
     this.editors = {};
-  },
+  }
 
   setLocation(pageName, hash) {
     this.setState({ activePage: pageName }, () => {
       if (hash) location.href = hash;
     });
-  },
+  }
 
   handlePageReady(pageName, editor) {
     if (editor) {
       this.editors[pageName] = editor;
     }
-    if (++this.readyPageCount === this.pages.length) {
+    if (++this.readyPageCount === OptionsView.pages.length) {
       this.setState({ saveEnabled: true, activePage: "rules" });
     }
-  },
+  }
   handlePageChange(page) {
     if (!this.state.activePage) return;
     this.setState({ activePage: page });
-  },
+  }
   handleSaveClick() {
     if (this.validate()) {
       this.props.controller.save(
@@ -56,7 +68,8 @@ const OptionsView = React.createClass({
         this.editors.visual.serialize()
       );
     }
-  },
+  }
+
   validate() {
     return _.every(this.editors, (editor, pageName) => {
       const errors = editor.validate();
@@ -66,13 +79,7 @@ const OptionsView = React.createClass({
       }
       return true;
     });
-  },
-
-  pages: [
-    { name: "rules", menuTitle: "menuRules", pageTitle: "customizeRules", icon: "pencil" },
-    { name: "visual", menuTitle: "menuVisual", pageTitle: "visualEffects", icon: "eye" },
-    { name: "about", menuTitle: "menuAbout", pageTitle: "aboutExtension", icon: "info-circle" },
-  ],
+  }
 
   render() {
     const { bundles, rules, appOptions, appVersion, appStoreURL } = this.props;
@@ -103,12 +110,12 @@ const OptionsView = React.createClass({
             <PageSwitch
               activePage={activePage}
               onPageChange={this.handlePageChange}
-              pages={this.pages}
+              pages={OptionsView.pages}
             />
           </div>
           <div className="main-pane">
             <div className="tab-content">
-              {this.pages.map(page =>
+              {OptionsView.pages.map(page =>
                 <PagePanel
                   key={page.name}
                   active={activePage === page.name}
@@ -131,7 +138,5 @@ const OptionsView = React.createClass({
         </div>
       </div>
     );
-  },
-});
-
-export default OptionsView;
+  }
+}

--- a/app/scripts/lib/options/view/pages/page-panel.js
+++ b/app/scripts/lib/options/view/pages/page-panel.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/pages/page-panel.js
+++ b/app/scripts/lib/options/view/pages/page-panel.js
@@ -2,16 +2,17 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const PagePanel = React.createClass({
-  propTypes: {
-    active: React.PropTypes.bool,
-    title: React.PropTypes.string.isRequired,
-    icon: React.PropTypes.string.isRequired,
-    children: React.PropTypes.any,
-  },
+export default class PagePanel extends React.Component {
+  static propTypes = {
+    active: PropTypes.bool,
+    title: PropTypes.string.isRequired,
+    icon: PropTypes.string.isRequired,
+    children: PropTypes.any,
+  };
+
   render() {
     const { active, title, icon } = this.props;
     return (
@@ -23,7 +24,5 @@ const PagePanel = React.createClass({
         {this.props.children}
       </div>
     );
-  },
-});
-
-export default PagePanel;
+  }
+}

--- a/app/scripts/lib/options/view/pages/page-switch.js
+++ b/app/scripts/lib/options/view/pages/page-switch.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/pages/page-switch.js
+++ b/app/scripts/lib/options/view/pages/page-switch.js
@@ -2,19 +2,20 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const PageSwitch = React.createClass({
-  propTypes: {
-    pages: React.PropTypes.arrayOf(React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      menuTitle: React.PropTypes.string.isRequired,
-      icon: React.PropTypes.string.isRequired,
+export default class PageSwitch extends React.Component {
+  static propTypes = {
+    pages: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      menuTitle: PropTypes.string.isRequired,
+      icon: PropTypes.string.isRequired,
     })).isRequired,
-    activePage: React.PropTypes.string,
-    onPageChange: React.PropTypes.func,
-  },
+    activePage: PropTypes.string,
+    onPageChange: PropTypes.func,
+  };
+
   render() {
     const { pages, activePage, onPageChange } = this.props;
     return (
@@ -29,7 +30,5 @@ const PageSwitch = React.createClass({
         )}
       </ul>
     );
-  },
-});
-
-export default PageSwitch;
+  }
+}

--- a/app/scripts/lib/options/view/rules/rule-editor.js
+++ b/app/scripts/lib/options/view/rules/rule-editor.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import JsonEditor from "../json-editor/json-editor";

--- a/app/scripts/lib/options/view/rules/rule-editor.js
+++ b/app/scripts/lib/options/view/rules/rule-editor.js
@@ -2,21 +2,28 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import JsonEditor from "../json-editor/json-editor";
 
-const RuleEditor = React.createClass({
-  propTypes: {
-    rule: React.PropTypes.shape({
-      key: React.PropTypes.string.isRequired,
-      schema: React.PropTypes.object.isRequired,
-      options: React.PropTypes.any,
+export default class RuleEditor extends React.Component {
+  static propTypes = {
+    rule: PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      schema: PropTypes.object.isRequired,
+      options: PropTypes.any,
     }).isRequired,
-    onReady: React.PropTypes.func.isRequired,
-  },
+    onReady: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.handleEditorReady = this.handleEditorReady.bind(this);
+  }
+
   handleEditorReady() {
     this.props.onReady(this.refs.editor);
-  },
+  }
+
   render() {
     const { rule } = this.props;
     return (
@@ -27,7 +34,5 @@ const RuleEditor = React.createClass({
         onReady={this.handleEditorReady}
       />
     );
-  },
-});
-
-export default RuleEditor;
+  }
+}

--- a/app/scripts/lib/options/view/rules/rule-item.js
+++ b/app/scripts/lib/options/view/rules/rule-item.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/rules/rule-item.js
+++ b/app/scripts/lib/options/view/rules/rule-item.js
@@ -2,30 +2,31 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 import SeveritySwitch from "./severity-switch";
 import RuleToggle from "./rule-toggle";
 import RuleEditor from "./rule-editor";
 
-const RuleItem = React.createClass({
-  propTypes: {
-    rule: React.PropTypes.shape({
-      key: React.PropTypes.string.isRequired,
-      schema: React.PropTypes.object.isRequired,
-      options: React.PropTypes.any,
-      description: React.PropTypes.string.isRequired,
-      version: React.PropTypes.string.isRequired,
-      author: React.PropTypes.string.isRequired,
-      homepage: React.PropTypes.string.isRequired,
+export default class RuleItem extends React.Component {
+  static propTypes = {
+    rule: PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      schema: PropTypes.object.isRequired,
+      options: PropTypes.any,
+      description: PropTypes.string.isRequired,
+      version: PropTypes.string.isRequired,
+      author: PropTypes.string.isRequired,
+      homepage: PropTypes.string.isRequired,
     }).isRequired,
-    enabled: React.PropTypes.bool.isRequired,
-    severity: React.PropTypes.string.isRequired,
-    filtered: React.PropTypes.bool.isRequired,
-    onSeveritySelect: React.PropTypes.func.isRequired,
-    onEnabledChange: React.PropTypes.func.isRequired,
-    onEditorReady: React.PropTypes.func.isRequired,
-  },
+    enabled: PropTypes.bool.isRequired,
+    severity: PropTypes.string.isRequired,
+    filtered: PropTypes.bool.isRequired,
+    onSeveritySelect: PropTypes.func.isRequired,
+    onEnabledChange: PropTypes.func.isRequired,
+    onEditorReady: PropTypes.func.isRequired,
+  };
+
   render() {
     const { rule, enabled, severity, filtered } = this.props;
     const className = [
@@ -66,7 +67,5 @@ const RuleItem = React.createClass({
         </div>
       </form>
     );
-  },
-});
-
-export default RuleItem;
+  }
+}

--- a/app/scripts/lib/options/view/rules/rule-list-editor.js
+++ b/app/scripts/lib/options/view/rules/rule-list-editor.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/options/view/rules/rule-list-editor.js
+++ b/app/scripts/lib/options/view/rules/rule-list-editor.js
@@ -3,26 +3,32 @@
 "use strict";
 
 import _ from "lodash";
-import React from "react";
+import React, { PropTypes } from "react";
 import RuleList from "./rule-list";
 
-const RuleListEditor = React.createClass({
-  propTypes: {
-    rules: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    onReady: React.PropTypes.func.isRequired,
-  },
+export default class RuleListEditor extends React.Component {
+  static propTypes = {
+    rules: PropTypes.arrayOf(PropTypes.object).isRequired,
+    onReady: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.handleEditorReady = this.handleEditorReady.bind(this);
+  }
 
   componentWillMount() {
     this.editors = {};
     this.editorCount = 0;
-  },
+  }
+
   handleEditorReady(ruleKey, editor) {
     this.editors[ruleKey] = editor;
     this.editorCount++;
     if (this.editorCount === this.props.rules.length) {
       this.props.onReady(this);
     }
-  },
+  }
 
   validate() {
     let errors = [];
@@ -37,7 +43,7 @@ const RuleListEditor = React.createClass({
     });
     if (location) errors.location = location;
     return errors;
-  },
+  }
   serialize() {
     const serialized = {};
     const ruleList = this.refs.ruleList;
@@ -50,7 +56,7 @@ const RuleListEditor = React.createClass({
       }
     });
     return serialized;
-  },
+  }
 
   render() {
     return (
@@ -60,7 +66,5 @@ const RuleListEditor = React.createClass({
         onEditorReady={this.handleEditorReady}
       />
     );
-  },
-});
-
-export default RuleListEditor;
+  }
+}

--- a/app/scripts/lib/options/view/rules/rule-list-filter.js
+++ b/app/scripts/lib/options/view/rules/rule-list-filter.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/options/view/rules/rule-list-filter.js
+++ b/app/scripts/lib/options/view/rules/rule-list-filter.js
@@ -3,14 +3,15 @@
 "use strict";
 
 import _ from "lodash";
-import React from "react";
+import React, { PropTypes } from "react";
 import escapeStringRegexp from "escape-string-regexp";
 import { translate } from "../../../util/chrome-util";
 
-const RuleListFilter = React.createClass({
-  propTypes: {
-    onFilterChange: React.PropTypes.func.isRequired,
-  },
+export default class RuleListFilter extends React.Component {
+  static propTypes = {
+    onFilterChange: PropTypes.func.isRequired,
+  };
+
   handleFilterChange(filterString) {
     const words = _.reject((filterString || "").split(/\s+/), _.isEmpty);
     let newFilter = null;
@@ -18,7 +19,8 @@ const RuleListFilter = React.createClass({
       newFilter = new RegExp(words.map(escapeStringRegexp).join("|"), "i");
     }
     this.props.onFilterChange(newFilter);
-  },
+  }
+
   render() {
     return (
       <div className="rule-list-filter form-inline">
@@ -32,7 +34,5 @@ const RuleListFilter = React.createClass({
         </div>
       </div>
     );
-  },
-});
-
-export default RuleListFilter;
+  }
+}

--- a/app/scripts/lib/options/view/rules/rule-list-toggle.js
+++ b/app/scripts/lib/options/view/rules/rule-list-toggle.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/rules/rule-list-toggle.js
+++ b/app/scripts/lib/options/view/rules/rule-list-toggle.js
@@ -2,14 +2,15 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const RuleListToggle = React.createClass({
-  propTypes: {
-    onTurnOnClick: React.PropTypes.func.isRequired,
-    onTurnOffClick: React.PropTypes.func.isRequired,
-  },
+export default class RuleListToggle extends React.Component {
+  static propTypes = {
+    onTurnOnClick: PropTypes.func.isRequired,
+    onTurnOffClick: PropTypes.func.isRequired,
+  };
+
   render() {
     return (
       <div className="rule-list-toggle">
@@ -23,7 +24,5 @@ const RuleListToggle = React.createClass({
         </button>
       </div>
     );
-  },
-});
-
-export default RuleListToggle;
+  }
+}

--- a/app/scripts/lib/options/view/rules/rule-list.js
+++ b/app/scripts/lib/options/view/rules/rule-list.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/options/view/rules/rule-list.js
+++ b/app/scripts/lib/options/view/rules/rule-list.js
@@ -3,32 +3,41 @@
 "use strict";
 
 import _ from "lodash";
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 import RuleListFilter from "./rule-list-filter";
 import RuleListToggle from "./rule-list-toggle";
 import RuleItem from "./rule-item";
 
-const RuleList = React.createClass({
-  propTypes: {
-    rules: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    onEditorReady: React.PropTypes.func.isRequired,
-  },
-  getInitialState() {
+export default class RuleList extends React.Component {
+  static propTypes = {
+    rules: PropTypes.arrayOf(PropTypes.object).isRequired,
+    onEditorReady: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
     const ruleMap = _.keyBy(this.props.rules, "key");
-    return {
+    this.state = {
       rulesFiltered: _.mapValues(ruleMap, _.constant(false)),
       rulesEnabled: _.mapValues(ruleMap, "enabled"),
       rulesSeverity: _.mapValues(ruleMap, "severity"),
     };
-  },
+
+    this.handleFilterChange = this.handleFilterChange.bind(this);
+    this.handleTurnOnClick = this.handleTurnOnClick.bind(this);
+    this.handleTurnOffClick = this.handleTurnOffClick.bind(this);
+    this.handleSeveritySelect = this.handleSeveritySelect.bind(this);
+    this.handleEnabledChange = this.handleEnabledChange.bind(this);
+  }
 
   getRuleSeverity(rule) {
     return this.state.rulesSeverity[rule.key ? rule.key : rule];
-  },
+  }
   isRuleEnabled(rule) {
     return this.state.rulesEnabled[rule.key ? rule.key : rule];
-  },
+  }
 
   handleFilterChange(filter) {
     const match = filter ? (rule) =>
@@ -38,23 +47,24 @@ const RuleList = React.createClass({
 
     const newFiltered = _.reduce(this.props.rules, (a, r) => (a[r.key] = !match(r), a), {});
     this.setState({ rulesFiltered: newFiltered });
-  },
+  }
   handleTurnOnClick() {
     const newEnabled = _.mapValues(this.state.rulesEnabled, _.constant(true));
     this.setState({ rulesEnabled: newEnabled });
-  },
+  }
   handleTurnOffClick() {
     const newEnabled = _.mapValues(this.state.rulesEnabled, _.constant(false));
     this.setState({ rulesEnabled: newEnabled });
-  },
+  }
   handleSeveritySelect(key, severity) {
     const newSeverity = _.defaults({ [key]: severity }, this.state.rulesSeverity);
     this.setState({ rulesSeverity: newSeverity });
-  },
+  }
   handleEnabledChange(key, enabled) {
     const newEnabled = _.defaults({ [key]: enabled }, this.state.rulesEnabled);
     this.setState({ rulesEnabled: newEnabled });
-  },
+  }
+
   render() {
     const { rules } = this.props;
     const { rulesFiltered, rulesEnabled, rulesSeverity } = this.state;
@@ -83,7 +93,5 @@ const RuleList = React.createClass({
         </div>
       </div>
     );
-  },
-});
-
-export default RuleList;
+  }
+}

--- a/app/scripts/lib/options/view/rules/rule-toggle.js
+++ b/app/scripts/lib/options/view/rules/rule-toggle.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import $ from "jquery";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/options/view/rules/rule-toggle.js
+++ b/app/scripts/lib/options/view/rules/rule-toggle.js
@@ -3,13 +3,14 @@
 "use strict";
 
 import $ from "jquery";
-import React from "react";
+import React, { PropTypes } from "react";
 
-const RuleToggle = React.createClass({
-  propTypes: {
-    enabled: React.PropTypes.bool.isRequired,
-    onChange: React.PropTypes.func.isRequired,
-  },
+export default class RuleToggle extends React.Component {
+  static propTypes = {
+    enabled: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+  };
+
   componentDidMount() {
     $(this.refs.checkbox).bootstrapSwitch({
       size: "mini",
@@ -17,10 +18,11 @@ const RuleToggle = React.createClass({
         this.props.onChange(checked);
       },
     });
-  },
+  }
   componentDidUpdate() {
     $(this.refs.checkbox).bootstrapSwitch("state", this.props.enabled);
-  },
+  }
+
   render() {
     return (
       <div className="rule-toggle">
@@ -30,7 +32,5 @@ const RuleToggle = React.createClass({
         />
       </div>
     );
-  },
-});
-
-export default RuleToggle;
+  }
+}

--- a/app/scripts/lib/options/view/rules/rules-page.js
+++ b/app/scripts/lib/options/view/rules/rules-page.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import RuleListEditor from "./rule-list-editor";

--- a/app/scripts/lib/options/view/rules/rules-page.js
+++ b/app/scripts/lib/options/view/rules/rules-page.js
@@ -2,14 +2,15 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import RuleListEditor from "./rule-list-editor";
 
-const RulesPage = React.createClass({
-  propTypes: {
-    rules: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    onReady: React.PropTypes.func.isRequired,
-  },
+export default class RulesPage extends React.Component {
+  static propTypes = {
+    rules: PropTypes.arrayOf(PropTypes.object).isRequired,
+    onReady: PropTypes.func.isRequired,
+  };
+
   render() {
     return (
       <div className="rule-page">
@@ -19,7 +20,5 @@ const RulesPage = React.createClass({
         />
       </div>
     );
-  },
-});
-
-export default RulesPage;
+  }
+}

--- a/app/scripts/lib/options/view/rules/severity-switch.js
+++ b/app/scripts/lib/options/view/rules/severity-switch.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/options/view/rules/severity-switch.js
+++ b/app/scripts/lib/options/view/rules/severity-switch.js
@@ -2,25 +2,25 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const Severities = [
-  { name: "error", title: "showAsErrors" },
-  { name: "warning", title: "showAsWarnings" },
-  { name: "info", title: "showAsInfo" },
-];
+export default class SeveritySwitch extends React.Component {
+  static propTypes = {
+    selected: PropTypes.string.isRequired,
+    onSelect: PropTypes.func.isRequired,
+  };
+  static severities = [
+    { name: "error", title: "showAsErrors" },
+    { name: "warning", title: "showAsWarnings" },
+    { name: "info", title: "showAsInfo" },
+  ];
 
-const SeveritySwitch = React.createClass({
-  propTypes: {
-    selected: React.PropTypes.string.isRequired,
-    onSelect: React.PropTypes.func.isRequired,
-  },
   render() {
     const { selected, onSelect } = this.props;
     return (
       <div className="severity-switch btn-group">
-        {Severities.map(({ name, title }) =>
+        {SeveritySwitch.severities.map(({ name, title }) =>
           <button
             key={name}
             className={[
@@ -36,7 +36,5 @@ const SeveritySwitch = React.createClass({
         )}
       </div>
     );
-  },
-});
-
-export default SeveritySwitch;
+  }
+}

--- a/app/scripts/lib/options/view/visual/visual-editor.js
+++ b/app/scripts/lib/options/view/visual/visual-editor.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import JsonEditor from "../json-editor/json-editor";

--- a/app/scripts/lib/options/view/visual/visual-editor.js
+++ b/app/scripts/lib/options/view/visual/visual-editor.js
@@ -2,18 +2,25 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import JsonEditor from "../json-editor/json-editor";
 
-const VisualEditor = React.createClass({
-  propTypes: {
-    visualOptionsSchema: React.PropTypes.object.isRequired,
-    visualOptions: React.PropTypes.object.isRequired,
-    onReady: React.PropTypes.func.isRequired,
-  },
+export default class VisualEditor extends React.Component {
+  static propTypes = {
+    visualOptionsSchema: PropTypes.object.isRequired,
+    visualOptions: PropTypes.object.isRequired,
+    onReady: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.handleEditorReady = this.handleEditorReady.bind(this);
+  }
+
   handleEditorReady() {
     this.props.onReady(this.refs.editor);
-  },
+  }
+
   render() {
     return (
       <JsonEditor
@@ -23,7 +30,5 @@ const VisualEditor = React.createClass({
         onReady={this.handleEditorReady}
       />
     );
-  },
-});
-
-export default VisualEditor;
+  }
+}

--- a/app/scripts/lib/options/view/visual/visual-page.js
+++ b/app/scripts/lib/options/view/visual/visual-page.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import VisualEditor from "./visual-editor";

--- a/app/scripts/lib/options/view/visual/visual-page.js
+++ b/app/scripts/lib/options/view/visual/visual-page.js
@@ -2,14 +2,15 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import VisualEditor from "./visual-editor";
 
-const VisualPage = React.createClass({
-  propTypes: {
-    appOptions: React.PropTypes.object.isRequired,
-    onReady: React.PropTypes.func.isRequired,
-  },
+export default class VisualPage extends React.Component {
+  static propTypes = {
+    appOptions: PropTypes.object.isRequired,
+    onReady: PropTypes.func.isRequired,
+  };
+
   render() {
     const { appOptions } = this.props;
     return (
@@ -21,7 +22,5 @@ const VisualPage = React.createClass({
         />
       </div>
     );
-  },
-});
-
-export default VisualPage;
+  }
+}

--- a/app/scripts/lib/popup/popup-controller.js
+++ b/app/scripts/lib/popup/popup-controller.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React from "react";
 import ReactDOM from "react-dom";

--- a/app/scripts/lib/popup/popup-settings.js
+++ b/app/scripts/lib/popup/popup-settings.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import appStorage from "../app/app-storage";

--- a/app/scripts/lib/popup/view/common/icon-button.js
+++ b/app/scripts/lib/popup/view/common/icon-button.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/popup/view/common/icon-button.js
+++ b/app/scripts/lib/popup/view/common/icon-button.js
@@ -2,19 +2,20 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const IconButton = React.createClass({
-  propTypes: {
-    icon: React.PropTypes.string.isRequired,
-    label: React.PropTypes.string.isRequired,
-    btn: React.PropTypes.string,
-    size: React.PropTypes.string,
-    active: React.PropTypes.bool,
-    disabled: React.PropTypes.bool,
-    onClick: React.PropTypes.func.isRequired,
-  },
+export default class IconButton extends React.Component {
+  static propTypes = {
+    icon: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    btn: PropTypes.string,
+    size: PropTypes.string,
+    active: PropTypes.bool,
+    disabled: PropTypes.bool,
+    onClick: PropTypes.func.isRequired,
+  };
+
   render() {
     const { icon, label, btn, size, active, disabled } = this.props;
 
@@ -33,7 +34,5 @@ const IconButton = React.createClass({
         <span>{translate(label)}</span>
       </button>
     );
-  },
-});
-
-export default IconButton;
+  }
+}

--- a/app/scripts/lib/popup/view/common/message-box.js
+++ b/app/scripts/lib/popup/view/common/message-box.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/popup/view/common/message-box.js
+++ b/app/scripts/lib/popup/view/common/message-box.js
@@ -2,17 +2,18 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const MessageBox = React.createClass({
-  propTypes: {
-    text: React.PropTypes.string.isRequired,
-    details: React.PropTypes.string,
-    mark: React.PropTypes.string.isRequired,
-    spin: React.PropTypes.bool,
-    children: React.PropTypes.element,
-  },
+export default class MessageBox extends React.Component {
+  static propTypes = {
+    text: PropTypes.string.isRequired,
+    details: PropTypes.string,
+    mark: PropTypes.string.isRequired,
+    spin: PropTypes.bool,
+    children: PropTypes.element,
+  };
+
   render() {
     const { text, details, mark, spin } = this.props;
     return (
@@ -23,7 +24,5 @@ const MessageBox = React.createClass({
         {this.props.children}
       </div>
     );
-  },
-});
-
-export default MessageBox;
+  }
+}

--- a/app/scripts/lib/popup/view/header/activate-toggle.js
+++ b/app/scripts/lib/popup/view/header/activate-toggle.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import IconButton from "../common/icon-button";

--- a/app/scripts/lib/popup/view/header/activate-toggle.js
+++ b/app/scripts/lib/popup/view/header/activate-toggle.js
@@ -2,15 +2,16 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import IconButton from "../common/icon-button";
 
-const ActivateToggle = React.createClass({
-  propTypes: {
-    active: React.PropTypes.bool.isRequired,
-    onClickActivate: React.PropTypes.func.isRequired,
-    onClickDeactivate: React.PropTypes.func.isRequired,
-  },
+export default class ActivateToggle extends React.Component {
+  static propTypes = {
+    active: PropTypes.bool.isRequired,
+    onClickActivate: PropTypes.func.isRequired,
+    onClickDeactivate: PropTypes.func.isRequired,
+  };
+
   render() {
     const { active, onClickActivate, onClickDeactivate } = this.props;
     return (
@@ -23,7 +24,5 @@ const ActivateToggle = React.createClass({
         />
       </div>
     );
-  },
-});
-
-export default ActivateToggle;
+  }
+}

--- a/app/scripts/lib/popup/view/header/header-panel.js
+++ b/app/scripts/lib/popup/view/header/header-panel.js
@@ -2,17 +2,18 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import OptionsButton from "./options-button";
 import ActivateToggle from "./activate-toggle";
 
-const HeaderPanel = React.createClass({
-  propTypes: {
-    controller: React.PropTypes.any.isRequired,
-    active: React.PropTypes.bool.isRequired,
-    onActivate: React.PropTypes.func.isRequired,
-    onDeactivate: React.PropTypes.func.isRequired,
-  },
+export default class HeaderPanel extends React.Component {
+  static propTypes = {
+    controller: PropTypes.any.isRequired,
+    active: PropTypes.bool.isRequired,
+    onActivate: PropTypes.func.isRequired,
+    onDeactivate: PropTypes.func.isRequired,
+  };
+
   render() {
     const { active } = this.props;
     return (
@@ -29,7 +30,5 @@ const HeaderPanel = React.createClass({
         </div>
       </div>
     );
-  },
-});
-
-export default HeaderPanel;
+  }
+}

--- a/app/scripts/lib/popup/view/header/header-panel.js
+++ b/app/scripts/lib/popup/view/header/header-panel.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import OptionsButton from "./options-button";

--- a/app/scripts/lib/popup/view/header/options-button.js
+++ b/app/scripts/lib/popup/view/header/options-button.js
@@ -4,17 +4,12 @@
 
 import React from "react";
 import IconButton from "../common/icon-button";
-import cutil from "../../../util/chrome-util";
+import { openOptionsPage } from "../../../util/chrome-util";
 
-const OptionsButton = React.createClass({
-  handleClick() {
-    cutil.openOptionsPage();
-  },
+export default class OptionsButton extends React.Component {
   render() {
     return (
-      <IconButton icon="cog" label="options" onClick={this.handleClick} />
+      <IconButton icon="cog" label="options" onClick={openOptionsPage} />
     );
-  },
-});
-
-export default OptionsButton;
+  }
+}

--- a/app/scripts/lib/popup/view/header/options-button.js
+++ b/app/scripts/lib/popup/view/header/options-button.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React from "react";
 import IconButton from "../common/icon-button";

--- a/app/scripts/lib/popup/view/marks/correct-buttons.js
+++ b/app/scripts/lib/popup/view/marks/correct-buttons.js
@@ -3,18 +3,19 @@
 "use strict";
 
 import _ from "lodash";
-import React from "react";
+import React, { PropTypes } from "react";
 import IconButton from "../common/icon-button";
 
-const CorrectButtons = React.createClass({
-  propTypes: {
-    marks: React.PropTypes.arrayOf(React.PropTypes.shape({
-      correctable: React.PropTypes.bool.isRequired,
+export default class CorrectButtons extends React.Component {
+  static propTypes = {
+    marks: PropTypes.arrayOf(PropTypes.shape({
+      correctable: PropTypes.bool.isRequired,
     })).isRequired,
-    hasUndo: React.PropTypes.bool.isRequired,
-    onUndoClick: React.PropTypes.func.isRequired,
-    onCorrectClick: React.PropTypes.func.isRequired,
-  },
+    hasUndo: PropTypes.bool.isRequired,
+    onUndoClick: PropTypes.func.isRequired,
+    onCorrectClick: PropTypes.func.isRequired,
+  };
+
   render() {
     const { marks, hasUndo, onUndoClick, onCorrectClick } = this.props;
     return (
@@ -31,7 +32,5 @@ const CorrectButtons = React.createClass({
         : ""}
       </div>
     );
-  },
-});
-
-export default CorrectButtons;
+  }
+}

--- a/app/scripts/lib/popup/view/marks/correct-buttons.js
+++ b/app/scripts/lib/popup/view/marks/correct-buttons.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/popup/view/marks/dismiss-button.js
+++ b/app/scripts/lib/popup/view/marks/dismiss-button.js
@@ -1,0 +1,38 @@
+/* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
+ * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
+"use strict";
+
+import React, { PropTypes } from "react";
+import { translate } from "../../../util/chrome-util";
+
+export default class DismissButton extends React.Component {
+  static propTypes = {
+    onDismissThisClick: PropTypes.func.isRequired,
+    onDismissSameClick: PropTypes.func.isRequired,
+  };
+
+  render() {
+    const { onDismissThisClick, onDismissSameClick } = this.props;
+    return (
+      <div className="btn-group mark-dismiss">
+        <a href="#" className="mark-item-menu-item" title={translate("dismissIt")}
+          data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+        >
+          <i className="fa fa-bell-slash"></i>
+        </a>
+        <ul className="dropdown-menu dropdown-menu-right">
+          <li>
+            <a href="#" className="mark-dismiss-this" onClick={onDismissThisClick}>
+              {translate("dismissOnlyThis")}
+            </a>
+          </li>
+          <li>
+            <a href="#" className="mark-dismiss-same" onClick={onDismissSameClick}>
+              {translate("dismissAllSame")}
+            </a>
+          </li>
+        </ul>
+      </div>
+    );
+  }
+}

--- a/app/scripts/lib/popup/view/marks/dismiss-button.js
+++ b/app/scripts/lib/popup/view/marks/dismiss-button.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/popup/view/marks/filter-item.js
+++ b/app/scripts/lib/popup/view/marks/filter-item.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/popup/view/marks/filter-item.js
+++ b/app/scripts/lib/popup/view/marks/filter-item.js
@@ -2,16 +2,17 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const FilterItem = React.createClass({
-  propTypes: {
-    severity: React.PropTypes.string.isRequired,
-    count: React.PropTypes.number.isRequired,
-    active: React.PropTypes.bool.isRequired,
-    onChange: React.PropTypes.func.isRequired,
-  },
+export default class FilterItem extends React.Component {
+  static propTypes = {
+    severity: PropTypes.string.isRequired,
+    count: PropTypes.number.isRequired,
+    active: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+  };
+
   render() {
     const { severity, count, active } = this.props;
     return (
@@ -24,7 +25,5 @@ const FilterItem = React.createClass({
         <span>{translate(severity)}</span>
       </button>
     );
-  },
-});
-
-export default FilterItem;
+  }
+}

--- a/app/scripts/lib/popup/view/marks/filter-list.js
+++ b/app/scripts/lib/popup/view/marks/filter-list.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/popup/view/marks/filter-list.js
+++ b/app/scripts/lib/popup/view/marks/filter-list.js
@@ -3,15 +3,16 @@
 "use strict";
 
 import _ from "lodash";
-import React from "react";
+import React, { PropTypes } from "react";
 import FilterItem from "./filter-item";
 
-const FilterList = React.createClass({
-  propTypes: {
-    counts: React.PropTypes.objectOf(React.PropTypes.number).isRequired,
-    actives: React.PropTypes.objectOf(React.PropTypes.bool).isRequired,
-    onFilterChange: React.PropTypes.func.isRequired,
-  },
+export default class FilterList extends React.Component {
+  static propTypes = {
+    counts: PropTypes.objectOf(PropTypes.number).isRequired,
+    actives: PropTypes.objectOf(PropTypes.bool).isRequired,
+    onFilterChange: PropTypes.func.isRequired,
+  };
+
   render() {
     const { counts, actives, onFilterChange } = this.props;
     return (
@@ -27,7 +28,5 @@ const FilterList = React.createClass({
         )}
       </div>
     );
-  },
-});
-
-export default FilterList;
+  }
+}

--- a/app/scripts/lib/popup/view/marks/mark-item.js
+++ b/app/scripts/lib/popup/view/marks/mark-item.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import $ from "jquery";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/popup/view/marks/mark-item.js
+++ b/app/scripts/lib/popup/view/marks/mark-item.js
@@ -3,32 +3,42 @@
 "use strict";
 
 import $ from "jquery";
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 import bundles from "../../../app/bundles";
+import DismissButton from "./dismiss-button";
+import UndismissButton from "./undismiss-button";
 
-const MarkItem = React.createClass({
-  propTypes: {
-    mark: React.PropTypes.shape({
-      severity: React.PropTypes.string.isRequired,
-      message: React.PropTypes.string.isRequired,
-      correctable: React.PropTypes.bool.isRequired,
-      dismissed: React.PropTypes.bool.isRequired,
-      ruleId: React.PropTypes.string.isRequired,
+export default class MarkItem extends React.Component {
+  static propTypes = {
+    mark: PropTypes.shape({
+      severity: PropTypes.string.isRequired,
+      message: PropTypes.string.isRequired,
+      correctable: PropTypes.bool.isRequired,
+      dismissed: PropTypes.bool.isRequired,
+      ruleId: PropTypes.string.isRequired,
     }).isRequired,
-    onMarkClick: React.PropTypes.func.isRequired,
-    onUndismissClick: React.PropTypes.func.isRequired,
-    onDismissThisClick: React.PropTypes.func.isRequired,
-    onDismissSameClick: React.PropTypes.func.isRequired,
-  },
+    onMarkClick: PropTypes.func.isRequired,
+    onUndismissClick: PropTypes.func.isRequired,
+    onDismissThisClick: PropTypes.func.isRequired,
+    onDismissSameClick: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.handleMarkClick = this.handleMarkClick.bind(this);
+  }
+
   getRuleHomepage() {
     const rule = bundles.get(this.props.mark.ruleId);
     return rule && rule.homepage;
-  },
+  }
+
   handleMarkClick(e) {
     if ($(e.target).parents(".mark-item-menu").length > 0) return;
     this.props.onMarkClick(e);
-  },
+  }
+
   render() {
     const { mark } = this.props;
     const ruleHomepage = this.getRuleHomepage();
@@ -68,44 +78,5 @@ const MarkItem = React.createClass({
         </div>
       </div>
     );
-  },
-});
-
-const UndismissButton = (props) => (
-  <a href="#" className="mark-item-menu-item mark-undismiss"
-    title={translate("undismissIt")} onClick={props.onClick}
-  >
-    <i className="fa fa-bell"></i>
-  </a>
-);
-UndismissButton.propTypes = {
-  onClick: React.PropTypes.func.isRequired,
-};
-
-const DismissButton = (props) => (
-  <div className="btn-group mark-dismiss">
-    <a href="#" className="mark-item-menu-item" title={translate("dismissIt")}
-      data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
-    >
-      <i className="fa fa-bell-slash"></i>
-    </a>
-    <ul className="dropdown-menu dropdown-menu-right">
-      <li>
-        <a href="#" className="mark-dismiss-this" onClick={props.onDismissThisClick}>
-          {translate("dismissOnlyThis")}
-        </a>
-      </li>
-      <li>
-        <a href="#" className="mark-dismiss-same" onClick={props.onDismissSameClick}>
-          {translate("dismissAllSame")}
-        </a>
-      </li>
-    </ul>
-  </div>
-);
-DismissButton.propTypes = {
-  onDismissThisClick: React.PropTypes.func.isRequired,
-  onDismissSameClick: React.PropTypes.func.isRequired,
-};
-
-export default MarkItem;
+  }
+}

--- a/app/scripts/lib/popup/view/marks/mark-list.js
+++ b/app/scripts/lib/popup/view/marks/mark-list.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/popup/view/marks/mark-list.js
+++ b/app/scripts/lib/popup/view/marks/mark-list.js
@@ -3,25 +3,27 @@
 "use strict";
 
 import _ from "lodash";
-import React from "react";
+import React, { PropTypes } from "react";
 import MarkItem from "./mark-item";
 
-const MarkList = React.createClass({
-  propTypes: {
-    actives: React.PropTypes.objectOf(React.PropTypes.bool).isRequired,
-    marks: React.PropTypes.arrayOf(React.PropTypes.shape({
-      markId: React.PropTypes.string.isRequired,
-      severity: React.PropTypes.string.isRequired,
+export default class MarkList extends React.Component {
+  static propTypes = {
+    actives: PropTypes.objectOf(PropTypes.bool).isRequired,
+    marks: PropTypes.arrayOf(PropTypes.shape({
+      markId: PropTypes.string.isRequired,
+      severity: PropTypes.string.isRequired,
     })).isRequired,
-    onMarkClick: React.PropTypes.func.isRequired,
-    onUndismissClick: React.PropTypes.func.isRequired,
-    onDismissThisClick: React.PropTypes.func.isRequired,
-    onDismissSameClick: React.PropTypes.func.isRequired,
-  },
+    onMarkClick: PropTypes.func.isRequired,
+    onUndismissClick: PropTypes.func.isRequired,
+    onDismissThisClick: PropTypes.func.isRequired,
+    onDismissSameClick: PropTypes.func.isRequired,
+  };
+
   getFilteredMarks() {
     const { actives } = this.props;
     return _.filter(this.props.marks, m => actives[m.dismissed ? "dismissed" : m.severity]);
-  },
+  }
+
   render() {
     const filteredMarks = this.getFilteredMarks();
     return (
@@ -38,7 +40,5 @@ const MarkList = React.createClass({
         )}
       </div>
     );
-  },
-});
-
-export default MarkList;
+  }
+}

--- a/app/scripts/lib/popup/view/marks/marks-panel.js
+++ b/app/scripts/lib/popup/view/marks/marks-panel.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import React, { PropTypes } from "react";

--- a/app/scripts/lib/popup/view/marks/marks-panel.js
+++ b/app/scripts/lib/popup/view/marks/marks-panel.js
@@ -3,47 +3,59 @@
 "use strict";
 
 import _ from "lodash";
-import React from "react";
+import React, { PropTypes } from "react";
 import FilterList from "./filter-list";
 import MarkList from "./mark-list";
 import CorrectButtons from "./correct-buttons";
 
-const MarksPanel = React.createClass({
-  propTypes: {
-    controller: React.PropTypes.any.isRequired,
-    counts: React.PropTypes.objectOf(React.PropTypes.number).isRequired,
-    marks: React.PropTypes.arrayOf(React.PropTypes.shape({
-      correctable: React.PropTypes.bool.isRequired,
+export default class MarksPanel extends React.Component {
+  static propTypes = {
+    controller: PropTypes.any.isRequired,
+    counts: PropTypes.objectOf(PropTypes.number).isRequired,
+    marks: PropTypes.arrayOf(PropTypes.shape({
+      correctable: PropTypes.bool.isRequired,
     })).isRequired,
-    hasUndo: React.PropTypes.bool.isRequired,
-  },
-  getInitialState() {
-    return {
+    hasUndo: PropTypes.bool.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
       actives: { error: true, warning: true, info: true },
     };
-  },
+
+    this.handleFilterChange = this.handleFilterChange.bind(this);
+    this.handleUndoClick = this.handleUndoClick.bind(this);
+    this.handleCorrectClick = this.handleCorrectClick.bind(this);
+    this.handleMarkClick = this.handleMarkClick.bind(this);
+    this.handleUndismissClick = this.handleUndismissClick.bind(this);
+    this.handleDismissThisClick = this.handleDismissThisClick.bind(this);
+    this.handleDismissSameClick = this.handleDismissSameClick.bind(this);
+  }
+
   handleFilterChange(severity, active) {
     const newActives = _.defaults({ [severity]: active }, this.state.actives);
     this.setState({ actives: newActives });
-  },
+  }
   handleUndoClick() {
     this.props.controller.undo();
-  },
+  }
   handleCorrectClick() {
     this.props.controller.correct();
-  },
+  }
   handleMarkClick(markId) {
     this.props.controller.showMark(markId);
-  },
+  }
   handleUndismissClick(markId) {
     this.props.controller.undismissMark(markId);
-  },
+  }
   handleDismissThisClick(markId) {
     this.props.controller.dismissThisMark(markId);
-  },
+  }
   handleDismissSameClick(markId) {
     this.props.controller.dismissSameMarks(markId);
-  },
+  }
+
   render() {
     const { counts, marks, hasUndo } = this.props;
     const { actives } = this.state;
@@ -66,7 +78,5 @@ const MarksPanel = React.createClass({
         />
       </div>
     );
-  },
-});
-
-export default MarksPanel;
+  }
+}

--- a/app/scripts/lib/popup/view/marks/undismiss-button.js
+++ b/app/scripts/lib/popup/view/marks/undismiss-button.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/popup/view/marks/undismiss-button.js
+++ b/app/scripts/lib/popup/view/marks/undismiss-button.js
@@ -5,14 +5,18 @@
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-export default class Pargraph extends React.Component {
+export default class UndismissButton extends React.Component {
   static propTypes = {
-    text: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
   };
 
   render() {
     return (
-      <p dangerouslySetInnerHTML={{ __html: translate(this.props.text) }}></p>
+      <a href="#" className="mark-item-menu-item mark-undismiss"
+        title={translate("undismissIt")} onClick={this.props.onClick}
+      >
+        <i className="fa fa-bell"></i>
+      </a>
     );
   }
 }

--- a/app/scripts/lib/popup/view/messages/error-message.js
+++ b/app/scripts/lib/popup/view/messages/error-message.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import MessageBox from "../common/message-box";

--- a/app/scripts/lib/popup/view/messages/error-message.js
+++ b/app/scripts/lib/popup/view/messages/error-message.js
@@ -2,20 +2,19 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import MessageBox from "../common/message-box";
 
-const ErrorMessage = React.createClass({
-  propTypes: {
-    reason: React.PropTypes.string,
-  },
+export default class ErrorMessage extends React.Component {
+  static propTypes = {
+    reason: PropTypes.string,
+  };
+
   render() {
     const { reason } = this.props;
     const details = DEBUG ? reason : null;
     return (
       <MessageBox text="wentWrong" details={details} mark="exclamation-triangle" />
     );
-  },
-});
-
-export default ErrorMessage;
+  }
+}

--- a/app/scripts/lib/popup/view/messages/linting-message.js
+++ b/app/scripts/lib/popup/view/messages/linting-message.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React from "react";
 import MessageBox from "../common/message-box";

--- a/app/scripts/lib/popup/view/messages/linting-message.js
+++ b/app/scripts/lib/popup/view/messages/linting-message.js
@@ -5,12 +5,10 @@
 import React from "react";
 import MessageBox from "../common/message-box";
 
-const LintingMessage = React.createClass({
+export default class LintingMessage extends React.Component {
   render() {
     return (
       <MessageBox text="linting" mark="circle-o-notch" spin />
     );
-  },
-});
-
-export default LintingMessage;
+  }
+}

--- a/app/scripts/lib/popup/view/messages/passed-message.js
+++ b/app/scripts/lib/popup/view/messages/passed-message.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import MessageBox from "../common/message-box";

--- a/app/scripts/lib/popup/view/messages/passed-message.js
+++ b/app/scripts/lib/popup/view/messages/passed-message.js
@@ -2,15 +2,16 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import MessageBox from "../common/message-box";
 import IconButton from "../common/icon-button";
 
-const PassedMessage = React.createClass({
-  propTypes: {
-    hasUndo: React.PropTypes.bool.isRequired,
-    onUndo: React.PropTypes.func.isRequired,
-  },
+export default class PassedMessage extends React.Component {
+  static propTypes = {
+    hasUndo: PropTypes.bool.isRequired,
+    onUndo: PropTypes.func.isRequired,
+  };
+
   render() {
     const { hasUndo, onUndo } = this.props;
     return (
@@ -20,7 +21,5 @@ const PassedMessage = React.createClass({
         : ""}
       </MessageBox>
     );
-  },
-});
-
-export default PassedMessage;
+  }
+}

--- a/app/scripts/lib/popup/view/messages/ready-message.js
+++ b/app/scripts/lib/popup/view/messages/ready-message.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React from "react";
 import MessageBox from "../common/message-box";

--- a/app/scripts/lib/popup/view/messages/ready-message.js
+++ b/app/scripts/lib/popup/view/messages/ready-message.js
@@ -5,12 +5,10 @@
 import React from "react";
 import MessageBox from "../common/message-box";
 
-const ReadyMessage = React.createClass({
+export default class ReadyMessage extends React.Component {
   render() {
     return (
       <MessageBox text="ready" mark="rocket" />
     );
-  },
-});
-
-export default ReadyMessage;
+  }
+}

--- a/app/scripts/lib/popup/view/messages/refresh-message.js
+++ b/app/scripts/lib/popup/view/messages/refresh-message.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import MessageBox from "../common/message-box";

--- a/app/scripts/lib/popup/view/messages/refresh-message.js
+++ b/app/scripts/lib/popup/view/messages/refresh-message.js
@@ -2,21 +2,27 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import MessageBox from "../common/message-box";
 import IconButton from "../common/icon-button";
 
-const RefreshMessage = React.createClass({
-  propTypes: {
-    onRefresh: React.PropTypes.func.isRequired,
-  },
-  getInitialState() {
-    return { refreshing: false };
-  },
+export default class RefreshMessage extends React.Component {
+  static propTypes = {
+    onRefresh: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { refreshing: false };
+
+    this.handleRefreshClick = this.handleRefreshClick.bind(this);
+  }
+
   handleRefreshClick() {
     this.setState({ refreshing: true });
     this.props.onRefresh();
-  },
+  }
+
   render() {
     const { refreshing } = this.state;
     return (
@@ -26,7 +32,5 @@ const RefreshMessage = React.createClass({
         />
       </MessageBox>
     );
-  },
-});
-
-export default RefreshMessage;
+  }
+}

--- a/app/scripts/lib/popup/view/popup-view.js
+++ b/app/scripts/lib/popup/view/popup-view.js
@@ -2,7 +2,7 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import ErrorMessage from "./messages/error-message";
 import LintingMessage from "./messages/linting-message";
 import ReadyMessage from "./messages/ready-message";
@@ -11,41 +11,49 @@ import HeaderPanel from "./header/header-panel";
 import MarksPanel from "./marks/marks-panel";
 import SettingsPanel from "./settings/settings-panel";
 
-const PopupView = React.createClass({
-  propTypes: {
-    controller: React.PropTypes.object.isRequired,
-    settings: React.PropTypes.object.isRequired,
-    rulesets: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-    contentStatus: React.PropTypes.shape({
-      active: React.PropTypes.bool.isRequired,
-      undoCount: React.PropTypes.number.isRequired,
-      counts: React.PropTypes.objectOf(React.PropTypes.number).isRequired,
-      marks: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+export default class PopupView extends React.Component {
+  static propTypes = {
+    controller: PropTypes.object.isRequired,
+    settings: PropTypes.object.isRequired,
+    rulesets: PropTypes.arrayOf(PropTypes.object).isRequired,
+    contentStatus: PropTypes.shape({
+      active: PropTypes.bool.isRequired,
+      undoCount: PropTypes.number.isRequired,
+      counts: PropTypes.objectOf(PropTypes.number).isRequired,
+      marks: PropTypes.arrayOf(PropTypes.object).isRequired,
     }).isRequired,
-    linterStatus: React.PropTypes.shape({
-      active: React.PropTypes.bool.isRequired,
-      waiting: React.PropTypes.bool.isRequired,
-      clientLinted: React.PropTypes.bool.isRequired,
+    linterStatus: PropTypes.shape({
+      active: PropTypes.bool.isRequired,
+      waiting: PropTypes.bool.isRequired,
+      clientLinted: PropTypes.bool.isRequired,
     }).isRequired,
-  },
-  getInitialState() {
-    return {
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
       ruleset: this.props.settings.ruleset || this.props.settings.preset, /* Backward-compat */
       format: this.props.settings.format,
     };
-  },
+
+    this.handleActivate = this.handleActivate.bind(this);
+    this.handleDeactivate = this.handleDeactivate.bind(this);
+    this.handleSettingsChange = this.handleSettingsChange.bind(this);
+    this.handleUndo = this.handleUndo.bind(this);
+  }
+
   handleActivate() {
     this.props.controller.activate(this.state);
-  },
+  }
   handleDeactivate() {
     this.props.controller.deactivate();
-  },
+  }
   handleSettingsChange(changes) {
     this.setState(changes);
-  },
+  }
   handleUndo() {
     this.props.controller.undo();
-  },
+  }
 
   renderContent() {
     const { controller, rulesets, contentStatus, linterStatus } = this.props;
@@ -76,7 +84,7 @@ const PopupView = React.createClass({
         hasUndo={contentStatus.undoCount > 0}
       />
     );
-  },
+  }
 
   render() {
     const { controller, contentStatus, linterStatus } = this.props;
@@ -96,7 +104,5 @@ const PopupView = React.createClass({
         {this.renderContent()}
       </div>
     );
-  },
-});
-
-export default PopupView;
+  }
+}

--- a/app/scripts/lib/popup/view/popup-view.js
+++ b/app/scripts/lib/popup/view/popup-view.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import ErrorMessage from "./messages/error-message";

--- a/app/scripts/lib/popup/view/settings/format-select.js
+++ b/app/scripts/lib/popup/view/settings/format-select.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/popup/view/settings/format-select.js
+++ b/app/scripts/lib/popup/view/settings/format-select.js
@@ -2,14 +2,15 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const FormatSelect = React.createClass({
-  propTypes: {
-    selected: React.PropTypes.string.isRequired,
-    onFormatSelect: React.PropTypes.func.isRequired,
-  },
+export default class FormatSelect extends React.Component {
+  static propTypes = {
+    selected: PropTypes.string.isRequired,
+    onFormatSelect: PropTypes.func.isRequired,
+  };
+
   render() {
     const { selected, onFormatSelect } = this.props;
     return (
@@ -23,7 +24,5 @@ const FormatSelect = React.createClass({
         </label>
       </div>
     );
-  },
-});
-
-export default FormatSelect;
+  }
+}

--- a/app/scripts/lib/popup/view/settings/ruleset-item.js
+++ b/app/scripts/lib/popup/view/settings/ruleset-item.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/popup/view/settings/ruleset-item.js
+++ b/app/scripts/lib/popup/view/settings/ruleset-item.js
@@ -2,15 +2,16 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 
-const RulesetItem = React.createClass({
-  propTypes: {
-    name: React.PropTypes.string.isRequired,
-    selected: React.PropTypes.bool.isRequired,
-    onClick: React.PropTypes.func.isRequired,
-  },
+export default class RulesetItem extends React.Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    selected: PropTypes.bool.isRequired,
+    onClick: PropTypes.func.isRequired,
+  };
+
   render() {
     const { name, selected, onClick } = this.props;
     return (
@@ -25,7 +26,5 @@ const RulesetItem = React.createClass({
         </label>
       </div>
     );
-  },
-});
-
-export default RulesetItem;
+  }
+}

--- a/app/scripts/lib/popup/view/settings/ruleset-list.js
+++ b/app/scripts/lib/popup/view/settings/ruleset-list.js
@@ -2,17 +2,18 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import RulesetItem from "./ruleset-item";
 
-const RulesetList = React.createClass({
-  propTypes: {
-    rulesets: React.PropTypes.arrayOf(React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
+export default class RulesetList extends React.Component {
+  static propTypes = {
+    rulesets: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string.isRequired,
     })).isRequired,
-    selected: React.PropTypes.string.isRequired,
-    onRulesetSelect: React.PropTypes.func.isRequired,
-  },
+    selected: PropTypes.string.isRequired,
+    onRulesetSelect: PropTypes.func.isRequired,
+  };
+
   render() {
     const { rulesets, selected, onRulesetSelect } = this.props;
     return (
@@ -27,7 +28,5 @@ const RulesetList = React.createClass({
         )}
       </div>
     );
-  },
-});
-
-export default RulesetList;
+  }
+}

--- a/app/scripts/lib/popup/view/settings/ruleset-list.js
+++ b/app/scripts/lib/popup/view/settings/ruleset-list.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import RulesetItem from "./ruleset-item";

--- a/app/scripts/lib/popup/view/settings/settings-panel.js
+++ b/app/scripts/lib/popup/view/settings/settings-panel.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";

--- a/app/scripts/lib/popup/view/settings/settings-panel.js
+++ b/app/scripts/lib/popup/view/settings/settings-panel.js
@@ -2,26 +2,34 @@
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 "use strict";
 
-import React from "react";
+import React, { PropTypes } from "react";
 import { translate } from "../../../util/chrome-util";
 import RulesetList from "./ruleset-list";
 import FormatSelect from "./format-select";
 
-const SettingsPanel = React.createClass({
-  propTypes: {
-    rulesets: React.PropTypes.arrayOf(React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
+export default class SettingsPanel extends React.Component {
+  static propTypes = {
+    rulesets: PropTypes.arrayOf(PropTypes.shape({
+      name: PropTypes.string.isRequired,
     })).isRequired,
-    ruleset: React.PropTypes.string,
-    format: React.PropTypes.string,
-    onChange: React.PropTypes.func.isRequired,
-  },
+    ruleset: PropTypes.string,
+    format: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.handleRulesetSelect = this.handleRulesetSelect.bind(this);
+    this.handleFormatSelect = this.handleFormatSelect.bind(this);
+  }
+
   handleRulesetSelect(rulesetName) {
     this.props.onChange({ ruleset: rulesetName });
-  },
+  }
   handleFormatSelect(formatName) {
     this.props.onChange({ format: formatName });
-  },
+  }
+
   render() {
     const { rulesets, ruleset, format } = this.props;
     return (
@@ -37,7 +45,5 @@ const SettingsPanel = React.createClass({
         </form>
       </div>
     );
-  },
-});
-
-export default SettingsPanel;
+  }
+}

--- a/app/scripts/lib/sandbox/index.js
+++ b/app/scripts/lib/sandbox/index.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import TextlintWrapper from "../textlint/textlint-wrapper";
 import sandboxServer from "./sandbox-server";

--- a/app/scripts/lib/sandbox/sandbox-server.js
+++ b/app/scripts/lib/sandbox/sandbox-server.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import messages from "../app/sandbox-message";
 

--- a/app/scripts/lib/textlint/textlint-rule-package.js
+++ b/app/scripts/lib/textlint/textlint-rule-package.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import $ from "jquery";
 import bundles from "../app/bundles";

--- a/app/scripts/lib/textlint/textlint-rulesets.js
+++ b/app/scripts/lib/textlint/textlint-rulesets.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import appConfig from "../app/app-config";

--- a/app/scripts/lib/textlint/textlint-wrapper.js
+++ b/app/scripts/lib/textlint/textlint-wrapper.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import { TextLintCore } from "textlint";

--- a/app/scripts/lib/util/chrome-util.js
+++ b/app/scripts/lib/util/chrome-util.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 

--- a/app/scripts/lib/util/strip-default.js
+++ b/app/scripts/lib/util/strip-default.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 export default function stripDefault(module) {
   return module && module.__esModule ? module.default : module;

--- a/app/scripts/lib/util/text-caret-scanner.js
+++ b/app/scripts/lib/util/text-caret-scanner.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 // RegExp to pick a word at caret in textarea.
 //  Since "\b" only represents boundary of English words,

--- a/app/scripts/options.js
+++ b/app/scripts/options.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import OptionsController from "./lib/options/options-controller";
 

--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import PopupController from "./lib/popup/popup-controller";
 

--- a/app/scripts/sandbox.js
+++ b/app/scripts/sandbox.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import sandbox from "./lib/sandbox/index";
 

--- a/app/scripts/shim/kuromoji/ChromeDictionaryLoader.js
+++ b/app/scripts/shim/kuromoji/ChromeDictionaryLoader.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 const DictionaryLoader = require("kuromoji/dist/node/loader/DictionaryLoader");
 

--- a/app/scripts/shim/prh/files.js
+++ b/app/scripts/shim/prh/files.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 export default {
   // for textlint-rule-preset-jtf-style

--- a/app/scripts/shim/prh/fs-mock.js
+++ b/app/scripts/shim/prh/fs-mock.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import path from "path";
 import files from "./files";

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
     "lint": "eslint --ignore-path .gitignore app/scripts tests tasks"
   },
   "devDependencies": {
+    "babel-eslint": "^6.0.3",
     "babel-loader": "^6.2.4",
+    "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "escape-string-regexp": "^1.0.5",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^7.0.0",
+    "eslint-plugin-import-order": "^2.1.2",
     "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-react": "^4.3.0",
     "glob": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-transform-runtime": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-react-optimize": "^1.0.1",
     "babel-preset-stage-2": "^6.5.0",
     "babel-register": "^6.7.2",
     "bower": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-transform-class-properties": "^6.6.0",
     "babel-plugin-transform-runtime": "^6.7.5",
+    "babel-plugin-transform-strict-mode": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-react-optimize": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "babel-register": "^6.7.2",
     "bower": "^1.7.9",
     "del": "^2.2.0",
-    "es6-promise": "^3.1.2",
     "escape-string-regexp": "^1.0.5",
     "eslint": "^2.8.0",
     "eslint-config-airbnb": "^7.0.0",

--- a/tasks/bower.js
+++ b/tasks/bower.js
@@ -1,9 +1,9 @@
+import path from "path";
 import gulp from "gulp";
 import gulpif from "gulp-if";
 import mainBowerFiles from "main-bower-files";
 import livereload from "gulp-livereload";
 import args from "./lib/args";
-import path from "path";
 
 gulp.task("bower", () => {
   return gulp.src(mainBowerFiles(), { base: path.join(__dirname, "..", "bower_components") })

--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -1,5 +1,5 @@
-import gulp from "gulp";
 import path from "path";
+import gulp from "gulp";
 import bundlejs from "./lib/bundlejs";
 
 gulp.task("bundle", () => {

--- a/tasks/dict.js
+++ b/tasks/dict.js
@@ -2,8 +2,8 @@ import gulp from "gulp";
 import gulpif from "gulp-if";
 import gunzip from "gulp-gunzip";
 import livereload from "gulp-livereload";
-import args from "./lib/args";
 import through from "through2";
+import args from "./lib/args";
 
 // Quickfix for gulp-gunzip does not add base to piped files
 function addBase(base) {

--- a/tasks/lib/bundlejs.js
+++ b/tasks/lib/bundlejs.js
@@ -1,7 +1,7 @@
-import gutil from "gulp-util";
-import _ from "lodash";
 import fs from "fs";
 import path from "path";
+import gutil from "gulp-util";
+import _ from "lodash";
 import through from "through2";
 import textlintRegistry from "textlint-registry";
 

--- a/tasks/lint.js
+++ b/tasks/lint.js
@@ -2,7 +2,7 @@ import gulp from "gulp";
 import eslint from "gulp-eslint";
 
 gulp.task("lint", () => {
-  return gulp.src(["**/*.js", "!node_modules/**", "!bower_components/**", "!dist/**"])
+  return gulp.src(["app/scripts/*.js", "tests/**/*.js", "tasks/**/*.js", "*.js"])
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());

--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -1,9 +1,9 @@
+import path from "path";
 import gulp from "gulp";
 import gulpif from "gulp-if";
 import livereload from "gulp-livereload";
-import args from "./lib/args";
 import jsonTransform from "gulp-json-transform";
-import path from "path";
+import args from "./lib/args";
 import applyBrowserPrefixesFor from "./lib/applyBrowserPrefixesFor";
 import expandGlobsFor from "./lib/expandGlobsFor";
 

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -1,3 +1,5 @@
+import path from "path";
+import _ from "lodash";
 import gulp from "gulp";
 import gulpif from "gulp-if";
 import webpack from "webpack";
@@ -9,8 +11,6 @@ import plumber from "gulp-plumber";
 import notify from "gulp-notify";
 import named from "vinyl-named";
 import args from "./lib/args";
-import _ from "lodash";
-import path from "path";
 
 const rootDir = path.join(__dirname, "..");
 const scriptsDir = `${rootDir}/app/scripts`;

--- a/tasks/templates/bundle.js.tpl
+++ b/tasks/templates/bundle.js.tpl
@@ -1,7 +1,6 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
 // This is auto-generated file by `gulp bundle`
-"use strict";
 
 /* eslint-disable */
 export default {

--- a/tests/entry.js
+++ b/tests/entry.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import $ from "jquery";
 import "./test-utils/with-promise";

--- a/tests/entry.js
+++ b/tests/entry.js
@@ -5,9 +5,6 @@
 import $ from "jquery";
 import "./test-utils/with-promise";
 
-// Polyfill Promise for PhantomJS
-require("es6-promise").polyfill();
-
 // Global sinon sandbox
 global.sinonsb = sinon.sandbox.create();
 

--- a/tests/lib/app/app-config-test.js
+++ b/tests/lib/app/app-config-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import appConfig from "../../../app/scripts/lib/app/app-config";

--- a/tests/lib/app/app-message-test.js
+++ b/tests/lib/app/app-message-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import appMessage from "../../../app/scripts/lib/app/app-message";
 

--- a/tests/lib/app/app-options-test.js
+++ b/tests/lib/app/app-options-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import AppOptions from "../../../app/scripts/lib/app/app-options";

--- a/tests/lib/app/app-storage-test.js
+++ b/tests/lib/app/app-storage-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import appStorage from "../../../app/scripts/lib/app/app-storage";
 

--- a/tests/lib/app/bundles-test.js
+++ b/tests/lib/app/bundles-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import bundles from "../../../tmp/bundle/bundles";

--- a/tests/lib/app/sandbox-message-test.js
+++ b/tests/lib/app/sandbox-message-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import sandboxMessage from "../../../app/scripts/lib/app/sandbox-message";
 

--- a/tests/lib/background/badge-test.js
+++ b/tests/lib/background/badge-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import Badge from "../../../app/scripts/lib/background/badge";

--- a/tests/lib/background/linter-status-test.js
+++ b/tests/lib/background/linter-status-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import LinterStatus from "../../../app/scripts/lib/background/linter-status";
 

--- a/tests/lib/background/linters-test.js
+++ b/tests/lib/background/linters-test.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 import _ from "lodash";
 import linters from "../../../app/scripts/lib/background/linters";

--- a/tests/test-utils/with-promise.js
+++ b/tests/test-utils/with-promise.js
@@ -1,6 +1,5 @@
 /* Copyright (C) 2016  IRIDE Monad <iride.monad@gmail.com>
  * License: GNU GPLv3 http://www.gnu.org/licenses/gpl-3.0.html */
-"use strict";
 
 global.withResolved = function (promise, fn) {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Improves settings for eslint and babel.

See commits for detailed information.

Some notable changes are:
- Add babel-plugin-transform-runtime plugin (4f1646c)
  - This enables generators/async functions and ES6 built-in classes such as Promise, Set, Symbol, etc.
  - It replaces es6-promise module.
- Migrate React components to ES6 class style (05e67ab)
  - Stop using `React.createClass` and use `React.Component` instead.
  - This is mainly for consistency. We will always write React components in ES6 class.
  - Introduced `babel-preset-react-optimize` plugin for optimizing classes into stateless functions.
- Remove "use strict" from every js files  (ab0f5bd)
  - No more "use strict" !
  - Introduced `babel-plugin-transform-strict-mode` plugin instead.
